### PR TITLE
Fix dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,15 @@
   ],
   "require": {
     "php": ">=8.1",
+    "altcha-org/altcha": "^1.1.1",
+    "symfony/console": "^6.4|^7.3"
     "symfony/form": "^6.4|^7.3",
     "symfony/framework-bundle": "^6.4|^7.3",
     "symfony/http-client": "^6.4|^7.3",
-    "symfony/yaml": "^6.4|^7.3",
-    "symfony/validator": "^6.4|^7.3",
-    "symfony/twig-bundle": "^6.4|^7.3",
     "symfony/translation": "^6.4|^7.3",
-    "altcha-org/altcha": "^1.1.1",
-    "symfony/twig-pack": "^1.0",
-    "symfony/console": "^6.4|^7.3"
+    "symfony/twig-bundle": "^6.4|^7.3",
+    "symfony/validator": "^6.4|^7.3",
+    "symfony/yaml": "^6.4|^7.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Remove twig-pack, as twig-extra-bundle isn't needed. Pack's aren't meant to be used in bundles anyways. Sorts require dependencies as well.